### PR TITLE
Download Wilde Type PDB File

### DIFF
--- a/flask-server/experiment/README.md
+++ b/flask-server/experiment/README.md
@@ -119,10 +119,14 @@ Shut down the server, change the directory to the `/flask-server` directory, and
 
 (See Postman for now, will be here later.)
 
-### 3.5 Validate PDB File.
+### 3.5 Upload PDB File.
 
 (See Postman for now, will be here later.)
 
-### 3.6 Generate Pattern
+### 3.6 Download PDB File
+
+(See Postman for now, will be here later.)
+
+### 3.7 Generate Pattern
 
 (See Postman for now, will be here later.)

--- a/flask-server/experiment/views.py
+++ b/flask-server/experiment/views.py
@@ -11,7 +11,7 @@
 # Here put the import lib.
 import os
 import prompts
-from flask import Response, request, redirect, jsonify
+from flask import Response, request, redirect, jsonify, send_file
 from flask_login import login_required, current_user
 from json import dumps
 from typing import List
@@ -216,9 +216,9 @@ def update_information(experiment_id: str):
         is_successful=True, message="The information is successfully updated.")
     return Response(response=response_info.serialize(), status=200, mimetype="application/json")
 
-@experiment_blueprint.route("/<experiment_id>/upload_pdb_file", methods=["POST"])
+@experiment_blueprint.route("/<experiment_id>/pdb_file", methods=["POST"])
 @login_required
-def upload_pdb_file(experiment_id: str):
+def pdb_file_upload(experiment_id: str):
     """Upload and Validate PDB File from the user.
     
     Args:
@@ -226,7 +226,6 @@ def upload_pdb_file(experiment_id: str):
     """
     user: User = current_user
     experiment = Experiment.get(experiment_id)
-    result = None
     message = str()
     is_valid = False
 
@@ -262,9 +261,7 @@ def upload_pdb_file(experiment_id: str):
                 sp = enzy_htp.structure.PDBParser()
                 stru = sp.get_structure(filepath)
                 if (stru.num_atoms > 0):
-                    result = is_structure_valid(stru, print_report=True)
-                    is_valid = result[0]
-                    intermediate_message = result[1]
+                    is_valid, intermediate_message = is_structure_valid(stru, print_report=True)
                     message += "The following errors were found in the PDB file: \n"
                     for reason, source, suggestion in intermediate_message:
                         message += f"Reason: {str(reason)}\tSource: {str(source)}\tSuggestion: {str(suggestion)};\n"
@@ -290,6 +287,49 @@ def upload_pdb_file(experiment_id: str):
         is_successful=is_valid,
         message=message)
     return Response(response=response_info.serialize(), status=200, mimetype="application/json")
+
+@experiment_blueprint.route("/<experiment_id>/pdb_file", methods=["GET"])
+@login_required
+def pdb_file_download(experiment_id: str):
+    """Download the PDB file attached to the experiment.
+    If the desired experiment doesn't exist or the selected experiment instance does not have PDB file attached, 404 NOT FOUND will be the response.
+        
+    Args:
+        experiment_id (str): The identifier of an experiment instance.
+    """
+    user: User = current_user
+    experiment = Experiment.get(experiment_id)
+
+    if not experiment:
+        response_info = ExperimentBehaviourResponseInfo(experiment=experiment, user=user,
+            is_successful=False,
+            message=f"The experiment with id '{experiment_id}' doesn't exist.")
+        return Response(response=response_info.serialize(), status=404, mimetype="application/json")
+
+    if experiment.user_id != user.id:
+        message = "You are not allowed to download file from this experiment."
+        response_info = ExperimentBehaviourResponseInfo(experiment=experiment, user=user,
+            is_successful=False,
+            message=message)
+        return Response(response=response_info.serialize(), status=403, mimetype="application/json")
+    
+    if (not experiment.pdb_filepath):
+        response_info = ExperimentBehaviourResponseInfo(experiment=experiment, user=user,
+            is_successful=False,
+            message=f"No PDB file attached.")
+        return Response(response=response_info.serialize(), status=404, mimetype="application/json")
+    if (os.path.isfile(experiment.pdb_filepath)):
+        base_filename = fs.base_file_name(experiment.pdb_filepath)
+        return send_file(path_or_file=experiment.pdb_filepath, mimetype="text/plain",
+            as_attachment=False, 
+            download_name=base_filename, 
+            attachment_filename=base_filename)
+    else:
+        response_info = ExperimentBehaviourResponseInfo(experiment=experiment, user=user,
+            is_successful=False,
+            message=f"Failed to find the attached PDB file.")
+        return Response(response=response_info.serialize(), status=404, mimetype="application/json")
+
 
 @experiment_blueprint.route("/<experiment_id>/generate_mutation_pattern", methods=["POST"])
 @login_required


### PR DESCRIPTION
Dear colleagues,

We are now able to upload/download PDB file attached to the experiment to/from `/api/experiment/<experiment_id: str>/pdb_file`. We use `POST` for uploading and `GET` for downloading.

Feel free to let me know if you have any questions!

Best,
Yinjie.