### PR TITLE
Clear thread information when deleting experiment.

### DIFF
--- a/flask-server/experiment/views.py
+++ b/flask-server/experiment/views.py
@@ -282,6 +282,10 @@ def delete_experiment():
             message=f"The experiment instance '{experiment_id}' is {StatusCode.status_text_mapper[experiment.status]}, which is unable to be deleted.")
         return Response(response=response_info.serialize(), status=400, mimetype="application/json")
     else:   # TODO (Zhong): Handling running experiment is a must.
+        OpenAIAssistant.delete_thread(
+            openai_secret_key=user.openai_secret_key, 
+            thread_id=experiment.current_thread_id
+        )
         experiment.clear_folder(remove_folder=True)
         db.experiments.delete_one({"id": experiment.id})
         # db.session.delete(experiment)

--- a/flask-server/services/openai_service.py
+++ b/flask-server/services/openai_service.py
@@ -184,6 +184,22 @@ class OpenAIAssistant(OpenAIChat):
         If `conversation_mode` is False, nothing will happen.
         
         Returns:
+            is_successful (bool): Indidate if the thread is refreshed.
+        """
+        try:
+            if (self.clear_thread()):
+                self.__thread = self.client.beta.threads.create()
+                return True
+            else:
+                return False
+        except:
+            return False
+        
+    def clear_thread(self):
+        """Clear the current thread. 
+        If `conversation_mode` is False, nothing will happen.
+        
+        Returns:
             is_successful (bool): Indidate if the thread is cleared.
         """
         try:


### PR DESCRIPTION
Dear Colleagues,

This PR is to add a feature that the thread created in user's OpenAI account for a specific experiment will be deleted when the user is deleting this experiment.

Best,
Yinjie.