### PR TITLE
Yinjie: Add `has_pdb_file` attribute to experiment and `Experiment.Assistant.POST` response.

### DIFF
--- a/flask-server/experiment/models.py
+++ b/flask-server/experiment/models.py
@@ -232,6 +232,13 @@ class Experiment():
         is_successful, mutants, message = self.get_mutants()
         return len(mutants)
 
+    @property
+    def has_pdb_file(self) -> bool:
+        if (self.pdb_filepath and os.path.isfile(self.pdb_filepath)):
+            return True
+        else:
+            return False
+
     @staticmethod
     def validate_pdb(pdb_file: str | FileStorage) -> Tuple[bool, str]:
         """Validate PDB file.
@@ -302,7 +309,7 @@ class Experiment():
 
         if (is_valid):
             filepath = os.path.join(save_folder, pdb_file.filename)
-            if (self.pdb_filepath and os.path.isfile(self.pdb_filepath)):
+            if self.has_pdb_file:
                 fs.safe_rm(self.pdb_filepath) # Delete existing file.
             pdb_file.save(filepath)
             self.pdb_filepath = filepath
@@ -336,7 +343,7 @@ class Experiment():
         is_successful = False
         mutants = list()
         message = str()
-        if (not os.path.isfile(self.pdb_filepath)):
+        if not self.has_pdb_file:
             message = "The current experiment isn't associated with any PDB file."
             return is_successful, mutants, message
 

--- a/flask-server/experiment/views.py
+++ b/flask-server/experiment/views.py
@@ -513,6 +513,7 @@ class AssistantsApi(Resource):
             is_successful=is_openai_key_valid, 
             message=f"Received response from OpenAI. Updates to the experiment configuration may be triggered.",
             response_content=response_content,
+            has_pdb_file=experiment.has_pdb_file,
             confirm_button=(status_code == 200 and any(signal in response_content.lower() for signal in confirm_signals)),
             tool_call_result=current_assistant.latest_tool_call_result,
             configuration_updated=configuration_updated,
@@ -626,7 +627,7 @@ class PdbFileApi(Resource):
             return notfound_response(user, experiment_id)
         if (experiment.user_id != user.id):
             return forbidden_response(user, experiment)    
-        if (not os.path.isfile(experiment.pdb_filepath)):
+        if not experiment.has_pdb_file:
             return no_pdb_response()
         else:
             base_filename = fs.base_file_name(experiment.pdb_filepath)
@@ -707,7 +708,7 @@ class MutationApi(Resource):
             return notfound_response(user, experiment_id)
         if (experiment.user_id != user.id):
             return forbidden_response(user, experiment)
-        if (not os.path.isfile(experiment.pdb_filepath)):
+        if not experiment.has_pdb_file:
             return no_pdb_response(user, experiment)
 
         mutation_request = request.form.get("mutation_request")
@@ -752,7 +753,7 @@ class MutationApi(Resource):
             return notfound_response(user, experiment_id)
         if (experiment.user_id != user.id):
             return forbidden_response(user, experiment)
-        if (not os.path.isfile(experiment.pdb_filepath)):
+        if not experiment.has_pdb_file:
             return no_pdb_response(user, experiment)
 
         mutation_pattern = request.form.get("mutation_pattern", None)
@@ -935,15 +936,8 @@ class SlurmCorrespondenceApi(Resource):
                 is_successful=False,
             )
             return Response(response=response_info.serialize(), status=409, mimetype="application/json")
-        elif (experiment.pdb_filepath == None or not os.path.isfile(experiment.pdb_filepath)):
-            response_info = ExperimentBehaviourResponseInfo(
-                experiment=experiment,
-                user=user,
-                message="This experiment does not contain a PDB file. Please upload your PDB file before submitting your computation.",
-                is_authenticated=True,
-                is_successful=False,
-            )
-            return Response(response=response_info.serialize(), status=415, mimetype="application/json")
+        elif not experiment.has_pdb_file:
+            return no_pdb_response()
         else:
             experiment_mutant_count = experiment.mutant_count
             if (experiment_mutant_count > MAX_MUTANT_COUNT):


### PR DESCRIPTION
Dear Colleagues,

This PR is to add a `has_pdb_file` attribute to experiment and `Experiment.Assistant.POST` response, so that the frontend can know if it is time to show `Drag and Drop .pdb files` input box.

Best,
Yinjie.